### PR TITLE
User can upload and view photos from the event

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,6 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="app/src/main/res/layout/activity_details.xml" value="0.29624633789062504" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.24230072463768115" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2107762654622396" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.2002716064453125" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,6 +12,7 @@
         <entry key="app/src/main/res/layout/item_event.xml" value="0.2668330307547928" />
         <entry key="app/src/main/res/menu/create_post.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/menu/logout.xml" value="0.2833333333333333" />
+        <entry key="app/src/main/res/xml/fileprovider.xml" value="0.1703125" />
       </map>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,6 +6,7 @@
         <entry key="app/src/main/res/layout/activity_details.xml" value="0.3100433349609376" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.24230072463768115" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2107762654622396" />
+        <entry key="app/src/main/res/layout/activity_photo_album.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.2002716064453125" />
         <entry key="app/src/main/res/layout/item_event.xml" value="0.2668330307547928" />
         <entry key="app/src/main/res/menu/logout.xml" value="0.2833333333333333" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,6 +10,7 @@
         <entry key="app/src/main/res/layout/activity_photo_album.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.2002716064453125" />
         <entry key="app/src/main/res/layout/item_event.xml" value="0.2668330307547928" />
+        <entry key="app/src/main/res/layout/item_photo.xml" value="0.2703804347826087" />
         <entry key="app/src/main/res/menu/create_post.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/menu/logout.xml" value="0.2833333333333333" />
         <entry key="app/src/main/res/xml/fileprovider.xml" value="0.1703125" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,12 +3,14 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
+        <entry key="app/src/main/res/layout/activity_add_photo.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/layout/activity_details.xml" value="0.3100433349609376" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.24230072463768115" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2107762654622396" />
         <entry key="app/src/main/res/layout/activity_photo_album.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.2002716064453125" />
         <entry key="app/src/main/res/layout/item_event.xml" value="0.2668330307547928" />
+        <entry key="app/src/main/res/menu/create_post.xml" value="0.33541666666666664" />
         <entry key="app/src/main/res/menu/logout.xml" value="0.2833333333333333" />
       </map>
     </option>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="app/src/main/res/layout/activity_details.xml" value="0.29624633789062504" />
+        <entry key="app/src/main/res/layout/activity_details.xml" value="0.3100433349609376" />
         <entry key="app/src/main/res/layout/activity_login.xml" value="0.24230072463768115" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2107762654622396" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.2002716064453125" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.firebase:firebase-ml-common:22.1.2'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -63,5 +64,4 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'org.parceler:parceler-api:1.1.12'
     annotationProcessor 'org.parceler:parceler:1.1.12'
-
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,5 +61,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'org.parceler:parceler-api:1.1.12'
+    annotationProcessor 'org.parceler:parceler:1.1.12'
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,5 +27,6 @@
         <activity android:name=".MainActivity" />
         <activity android:name=".SignUpActivity" />
         <activity android:name=".EventDetailsActivity" />
+        <activity android:name=".PhotoAlbumActivity" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,5 +26,6 @@
         </activity>
         <activity android:name=".MainActivity" />
         <activity android:name=".SignUpActivity" />
+        <activity android:name=".EventDetailsActivity" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,5 +28,6 @@
         <activity android:name=".SignUpActivity" />
         <activity android:name=".EventDetailsActivity" />
         <activity android:name=".PhotoAlbumActivity" />
+        <activity android:name=".AddPhotoActivity" />
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,12 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
+
     <application
         android:name=".ParseApplication"
         android:allowBackup="true"
@@ -16,6 +22,17 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Event_Finder_Capstone"
         tools:targetApi="31">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.codepath.photoprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/photoprovider" />
+        </provider>
+
         <activity
             android:name=".LoginActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
@@ -1,0 +1,15 @@
+package com.example.event_finder_capstone;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class AddPhotoActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_add_photo);
+
+    }
+}

--- a/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
@@ -49,6 +49,7 @@ public class AddPhotoActivity extends AppCompatActivity {
         setContentView(R.layout.activity_add_photo);
 
         event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+        getSupportActionBar().setTitle("Add Photos from " + event.getName());
 
         etDescription = findViewById(R.id.etDescription);
         Button btnCaptureImage = findViewById(R.id.btnCaptureImage);

--- a/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
@@ -7,7 +7,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
-import android.util.Log;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
@@ -92,7 +91,6 @@ public class AddPhotoActivity extends AppCompatActivity {
         photo.saveInBackground(e -> {
             if (e != null) {
                 Toast.makeText(AddPhotoActivity.this, "Error saving post!", Toast.LENGTH_LONG).show();
-                Log.e(TAG, e.toString());
             }
             Toast.makeText(AddPhotoActivity.this, "Posted!", Toast.LENGTH_LONG).show();
             etDescription.setText("");

--- a/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/AddPhotoActivity.java
@@ -1,15 +1,166 @@
 package com.example.event_finder_capstone;
 
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.MediaStore;
+import android.util.Log;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
+
+import com.example.event_finder_capstone.models.Event;
+import com.example.event_finder_capstone.models.Photo;
+import com.parse.ParseFile;
+import com.parse.ParseUser;
+
+import org.parceler.Parcels;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 public class AddPhotoActivity extends AppCompatActivity {
+
+    public static final int CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE = 1989;
+    static int PHOTO_WIDTH = 300;
+    static int PHOTO_QUALITY = 40;
+    public String photoFileName = "photo.jpg";
+    Event event;
+    String TAG = "AddPhotoActivity";
+    private EditText etDescription;
+    private ImageView ivPostImage;
+    private File photoFile;
+    private ProgressBar pb;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_add_photo);
 
+        event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+
+        etDescription = findViewById(R.id.etDescription);
+        Button btnCaptureImage = findViewById(R.id.btnCaptureImage);
+        ivPostImage = findViewById(R.id.ivPostImage);
+        Button btnSubmit = findViewById(R.id.btnSubmit);
+        pb = findViewById(R.id.pbLoading);
+
+        btnCaptureImage.setOnClickListener(v -> launchCamera());
+
+        btnSubmit.setOnClickListener(v -> {
+            pb.setVisibility(ProgressBar.VISIBLE);
+            submitPhotoToServer();
+        });
+
+    }
+
+    private void submitPhotoToServer() {
+        String description = etDescription.getText().toString();
+        String eventId = event.getId();
+        if (description.isEmpty()) {
+            Toast.makeText(AddPhotoActivity.this, "Description cannot be empty!", Toast.LENGTH_LONG).show();
+            pb.setVisibility(ProgressBar.INVISIBLE);
+            return;
+        }
+        if (photoFile == null || ivPostImage.getDrawable() == null) {
+            Toast.makeText(AddPhotoActivity.this, "Photo cannot be empty!", Toast.LENGTH_LONG).show();
+            pb.setVisibility(ProgressBar.INVISIBLE);
+            return;
+        }
+        ParseUser currentUser = ParseUser.getCurrentUser();
+        savePhoto(description, currentUser, photoFile, eventId);
+    }
+
+    private void savePhoto(String description, ParseUser currentUser, File photoFile, String eventId) {
+        Photo photo = new Photo();
+        photo.setEventId(event.getId());
+        photo.setDescription(description);
+        photo.setImage(new ParseFile(photoFile));
+        photo.setUser(currentUser);
+        photo.saveInBackground(e -> {
+            if (e != null) {
+                Toast.makeText(AddPhotoActivity.this, "Error saving post!", Toast.LENGTH_LONG).show();
+                Log.e(TAG, e.toString());
+            }
+            Toast.makeText(AddPhotoActivity.this, "Posted!", Toast.LENGTH_LONG).show();
+            etDescription.setText("");
+            ivPostImage.setImageResource(0);
+            pb.setVisibility(ProgressBar.INVISIBLE);
+        });
+    }
+
+    private void launchCamera() {
+        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+        photoFile = getPhotoFileUri(photoFileName);
+        Uri fileProvider = FileProvider.getUriForFile(AddPhotoActivity.this, "com.codepath.photoprovider", photoFile);
+        intent.putExtra(MediaStore.EXTRA_OUTPUT, fileProvider);
+        if (intent.resolveActivity(getPackageManager()) != null) {
+            startActivityForResult(intent, CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE);
+        }
+    }
+
+
+    private void resizePhoto(Bitmap resizedBitmap) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        resizedBitmap.compress(Bitmap.CompressFormat.JPEG, PHOTO_QUALITY, bytes);
+        File resizedFile = getPhotoFileUri(photoFileName + "_resized");
+        try {
+            resizedFile.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        FileOutputStream fos = null;
+        try {
+            fos = new FileOutputStream(resizedFile);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        try {
+            assert fos != null;
+            fos.write(bytes.toByteArray());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        try {
+            fos.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private File getPhotoFileUri(String photoFileName) {
+        File mediaStorageDir = new File(getExternalFilesDir(Environment.DIRECTORY_PICTURES), TAG);
+        if (!mediaStorageDir.exists() && !mediaStorageDir.mkdirs()) {
+            Toast.makeText(AddPhotoActivity.this, "Failed to create photo directory", Toast.LENGTH_LONG).show();
+        }
+        return new File(mediaStorageDir.getPath() + File.separator + photoFileName);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == CAPTURE_IMAGE_ACTIVITY_REQUEST_CODE) {
+            if (resultCode == RESULT_OK) {
+                Uri takenPhotoUri = Uri.fromFile(getPhotoFileUri(photoFileName));
+                Bitmap rawTakenImage = BitmapFactory.decodeFile(takenPhotoUri.getPath());
+                Bitmap resizedBitmap = BitmapScaler.scaleToFitWidth(rawTakenImage, PHOTO_WIDTH);
+                resizePhoto(resizedBitmap);
+                ivPostImage.setImageBitmap(resizedBitmap);
+            } else {
+                Toast.makeText(this, "Picture wasn't taken!", Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/event_finder_capstone/BitmapScaler.java
+++ b/app/src/main/java/com/example/event_finder_capstone/BitmapScaler.java
@@ -1,0 +1,10 @@
+package com.example.event_finder_capstone;
+
+import android.graphics.Bitmap;
+
+public class BitmapScaler {
+    public static Bitmap scaleToFitWidth(Bitmap b, int width) {
+        float factor = width / (float) b.getWidth();
+        return Bitmap.createScaledBitmap(b, width, (int) (b.getHeight() * factor), true);
+    }
+}

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,9 +1,12 @@
 package com.example.event_finder_capstone;
 
+import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
+
 import android.content.Context;
 import android.icu.text.DateFormat;
 import android.icu.text.SimpleDateFormat;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -50,8 +53,11 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         tvEventDetailsTitle.setText(event.getName());
         tvEventDetailsDescription.setText(event.getDescription());
-        //TODO: Figure out why not populating
-        tvEventDetailsSite.setText(event.getCategory());
+        tvEventDetailsSite.setText(event.getEventSiteUrl());
+        tvEventDetailsAddress.setText(event.getLocation());
+        Log.d(TAG, "site url" + (event.getEventSiteUrl()).toString());
+        tvEventDetailsCost.setText(event.getCost().toString());
+
         Glide.with(this).load(event.getImageUrl()).centerCrop().into(ivEventDetailsImage);
         try {
             tvEventDetailsStartDate.setText(convertEventDateFormat(event.getTimeStart()));

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,0 +1,7 @@
+package com.example.event_finder_capstone;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class EventDetailsActivity extends AppCompatActivity {
+
+}

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,14 +1,75 @@
 package com.example.event_finder_capstone;
 
+import android.content.Context;
+import android.icu.text.DateFormat;
+import android.icu.text.SimpleDateFormat;
 import android.os.Bundle;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
 
-import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.bumptech.glide.Glide;
+import com.example.event_finder_capstone.models.Event;
+
+import org.parceler.Parcels;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+
 public class EventDetailsActivity extends AppCompatActivity {
+    Context context;
+    Event event;
+
+    TextView tvEventDetailsTitle;
+    TextView tvEventDetailsDescription;
+    TextView tvEventDetailsStartDate;
+    TextView tvEventDetailsEndDate;
+    TextView tvEventDetailsAddress;
+    TextView tvEventDetailsSite;
+    TextView tvEventDetailsCost;
+    ImageView ivEventDetailsImage;
+
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+
+        tvEventDetailsTitle = (TextView) findViewById(R.id.tvEventDetailsTitle);
+        tvEventDetailsDescription = (TextView) findViewById(R.id.tvEventDetailsDescription);
+        tvEventDetailsStartDate = (TextView) findViewById(R.id.tvEventDetailsStartDate);
+        tvEventDetailsEndDate = (TextView) findViewById(R.id.tvEventDetailsEndDate);
+        tvEventDetailsAddress = (TextView) findViewById(R.id.tvEventDetailsAddress);
+        tvEventDetailsSite = (TextView) findViewById(R.id.tvEventDetailsSite);
+        tvEventDetailsCost = (TextView) findViewById(R.id.tvEventDetailsCost);
+        ivEventDetailsImage = (ImageView) findViewById(R.id.ivEventsDetailsImage);
+
+        event = (Event) Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+
+        tvEventDetailsTitle.setText(event.getName());
+        tvEventDetailsDescription.setText(event.getDescription());
+        //TODO: Figure out why not populating
+        tvEventDetailsSite.setText(event.getCategory());
+        Glide.with(this).load(event.getImageUrl()).centerCrop().into(ivEventDetailsImage);
+        try {
+            tvEventDetailsStartDate.setText(convertEventDateFormat(event.getTimeStart()));
+        } catch (ParseException e) {
+            Toast.makeText(EventDetailsActivity.this, "Failed to retrieve start date", Toast.LENGTH_SHORT).show();
+        }
+        try {
+            tvEventDetailsEndDate.setText(convertEventDateFormat(event.getTimeEnd()));
+        } catch (ParseException e) {
+            Toast.makeText(EventDetailsActivity.this, "Failed to retrieve end date", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private String convertEventDateFormat(String unformattedDate) throws ParseException {
+        DateFormat outputFormat = new SimpleDateFormat("MM/dd/yy", Locale.US);
+        DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+        Date formattedDate = inputFormat.parse(unformattedDate);
+        return outputFormat.format(formattedDate);
     }
 }
+

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,7 +1,14 @@
 package com.example.event_finder_capstone;
 
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class EventDetailsActivity extends AppCompatActivity {
-
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_details);
+    }
 }

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -63,7 +63,6 @@ public class EventDetailsActivity extends AppCompatActivity {
 
     private void setDetailsScreenText() {
         event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
-
         tvEventDetailsTitle.setText(event.getName());
         tvEventDetailsDescription.setText(event.getDescription());
         formatAndSetEventURL();

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,11 +1,14 @@
 package com.example.event_finder_capstone;
 
 import android.content.Context;
+import android.content.Intent;
 import android.icu.text.DateFormat;
 import android.icu.text.SimpleDateFormat;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
+import android.view.View;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -33,6 +36,7 @@ public class EventDetailsActivity extends AppCompatActivity {
     TextView tvEventDetailsSite;
     TextView tvEventDetailsCost;
     ImageView ivEventDetailsImage;
+    Button btnPhotoAlbum;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,7 +51,21 @@ public class EventDetailsActivity extends AppCompatActivity {
         tvEventDetailsSite = findViewById(R.id.tvEventDetailsSite);
         tvEventDetailsCost = findViewById(R.id.tvEventDetailsCost);
         ivEventDetailsImage = findViewById(R.id.ivEventsDetailsImage);
+        btnPhotoAlbum = findViewById(R.id.btnPhotoAlbum);
+
         setDetailsScreenText();
+
+        btnPhotoAlbum.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                goPhotoAlbum();
+            }
+        });
+    }
+
+    private void goPhotoAlbum() {
+        Intent intent = new Intent(EventDetailsActivity.this, PhotoAlbumActivity.class);
+        startActivity(intent);
     }
 
     private void setDetailsScreenText() {
@@ -89,5 +107,7 @@ public class EventDetailsActivity extends AppCompatActivity {
         Date formattedDate = inputFormat.parse(unformattedDate);
         return outputFormat.format(formattedDate);
     }
+
+
 }
 

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -55,9 +55,7 @@ public class EventDetailsActivity extends AppCompatActivity {
         tvEventDetailsDescription.setText(event.getDescription());
         tvEventDetailsSite.setText(event.getEventSiteUrl());
         tvEventDetailsAddress.setText(event.getLocation());
-        Log.d(TAG, "site url" + (event.getEventSiteUrl()).toString());
         tvEventDetailsCost.setText(event.getCost().toString());
-
         Glide.with(this).load(event.getImageUrl()).centerCrop().into(ivEventDetailsImage);
         try {
             tvEventDetailsStartDate.setText(convertEventDateFormat(event.getTimeStart()));

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,12 +1,11 @@
 package com.example.event_finder_capstone;
 
-import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
-
 import android.content.Context;
 import android.icu.text.DateFormat;
 import android.icu.text.SimpleDateFormat;
 import android.os.Bundle;
-import android.util.Log;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -40,23 +39,30 @@ public class EventDetailsActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
 
-        tvEventDetailsTitle = (TextView) findViewById(R.id.tvEventDetailsTitle);
-        tvEventDetailsDescription = (TextView) findViewById(R.id.tvEventDetailsDescription);
-        tvEventDetailsStartDate = (TextView) findViewById(R.id.tvEventDetailsStartDate);
-        tvEventDetailsEndDate = (TextView) findViewById(R.id.tvEventDetailsEndDate);
-        tvEventDetailsAddress = (TextView) findViewById(R.id.tvEventDetailsAddress);
-        tvEventDetailsSite = (TextView) findViewById(R.id.tvEventDetailsSite);
-        tvEventDetailsCost = (TextView) findViewById(R.id.tvEventDetailsCost);
-        ivEventDetailsImage = (ImageView) findViewById(R.id.ivEventsDetailsImage);
+        tvEventDetailsTitle = findViewById(R.id.tvEventDetailsTitle);
+        tvEventDetailsDescription = findViewById(R.id.tvEventDetailsDescription);
+        tvEventDetailsStartDate = findViewById(R.id.tvEventDetailsStartDate);
+        tvEventDetailsEndDate = findViewById(R.id.tvEventDetailsEndDate);
+        tvEventDetailsAddress = findViewById(R.id.tvEventDetailsAddress);
+        tvEventDetailsSite = findViewById(R.id.tvEventDetailsSite);
+        tvEventDetailsCost = findViewById(R.id.tvEventDetailsCost);
+        ivEventDetailsImage = findViewById(R.id.ivEventsDetailsImage);
+        setDetailsScreenText();
+    }
 
-        event = (Event) Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+    private void setDetailsScreenText() {
+        event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
 
         tvEventDetailsTitle.setText(event.getName());
         tvEventDetailsDescription.setText(event.getDescription());
-        tvEventDetailsSite.setText(event.getEventSiteUrl());
+        formatAndSetEventURL();
         tvEventDetailsAddress.setText(event.getLocation());
-        tvEventDetailsCost.setText(event.getCost().toString());
+        tvEventDetailsCost.setText(event.getCost());
         Glide.with(this).load(event.getImageUrl()).centerCrop().into(ivEventDetailsImage);
+        setEventStartAndEndDates();
+    }
+
+    private void setEventStartAndEndDates() {
         try {
             tvEventDetailsStartDate.setText(convertEventDateFormat(event.getTimeStart()));
         } catch (ParseException e) {
@@ -67,6 +73,14 @@ public class EventDetailsActivity extends AppCompatActivity {
         } catch (ParseException e) {
             Toast.makeText(EventDetailsActivity.this, "Failed to retrieve end date", Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private void formatAndSetEventURL() {
+        String link = event.getEventSiteUrl();
+        tvEventDetailsSite.setMovementMethod(LinkMovementMethod.getInstance());
+        tvEventDetailsSite.setClickable(true);
+        String text = "<a href='" + link + "'> Book Tickets and Learn More </a>";
+        tvEventDetailsSite.setText(Html.fromHtml(text));
     }
 
     private String convertEventDateFormat(String unformattedDate) throws ParseException {

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -24,7 +24,6 @@ import java.util.Locale;
 
 public class EventDetailsActivity extends AppCompatActivity {
     Event event;
-
     TextView tvEventDetailsTitle;
     TextView tvEventDetailsDescription;
     TextView tvEventDetailsStartDate;
@@ -39,6 +38,8 @@ public class EventDetailsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+
+        getSupportActionBar().setTitle("Event Details");
 
         tvEventDetailsTitle = findViewById(R.id.tvEventDetailsTitle);
         tvEventDetailsDescription = findViewById(R.id.tvEventDetailsDescription);

--- a/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventDetailsActivity.java
@@ -1,13 +1,11 @@
 package com.example.event_finder_capstone;
 
-import android.content.Context;
 import android.content.Intent;
 import android.icu.text.DateFormat;
 import android.icu.text.SimpleDateFormat;
 import android.os.Bundle;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
-import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -25,7 +23,6 @@ import java.util.Date;
 import java.util.Locale;
 
 public class EventDetailsActivity extends AppCompatActivity {
-    Context context;
     Event event;
 
     TextView tvEventDetailsTitle;
@@ -55,16 +52,12 @@ public class EventDetailsActivity extends AppCompatActivity {
 
         setDetailsScreenText();
 
-        btnPhotoAlbum.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                goPhotoAlbum();
-            }
-        });
+        btnPhotoAlbum.setOnClickListener(v -> goPhotoAlbum());
     }
 
     private void goPhotoAlbum() {
         Intent intent = new Intent(EventDetailsActivity.this, PhotoAlbumActivity.class);
+        intent.putExtra(Event.class.getSimpleName(), Parcels.wrap(event));
         startActivity(intent);
     }
 

--- a/app/src/main/java/com/example/event_finder_capstone/EventsAdapter.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventsAdapter.java
@@ -2,6 +2,7 @@ package com.example.event_finder_capstone;
 
 import android.content.Context;
 import android.content.Intent;
+import android.icu.text.DateFormat;
 import android.icu.text.SimpleDateFormat;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,8 +16,12 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 import com.example.event_finder_capstone.models.Event;
 
+import org.parceler.Parcels;
+
+import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder> {
 
@@ -38,7 +43,11 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         Event event = events.get(position);
-        holder.bind(event);
+        try {
+            holder.bind(event);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -46,7 +55,7 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
         return events.size();
     }
 
-    public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
+    public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
         ImageView ivEventPhoto;
         TextView tvEventTitle;
@@ -64,24 +73,27 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
             itemView.setOnClickListener(this);
         }
 
-        public void bind(Event event) {
+        public void bind(Event event) throws ParseException {
             tvEventTitle.setText(event.getName());
             tvEventDescription.setText(event.getDescription());
-            tvStartDate.setText(convertEventDateFormat());
-            tvEndDate.setText(convertEventDateFormat());
+            tvStartDate.setText(convertEventDateFormat(event.getTimeStart()));
+            tvEndDate.setText(convertEventDateFormat(event.getTimeEnd()));
             Glide.with(context).load(event.getImageUrl()).centerCrop().into(ivEventPhoto);
         }
 
-        private String convertEventDateFormat() {
-            Date date = new Date();
-            SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yy");
-            return formatter.format(date);
+        private String convertEventDateFormat(String unformattedDate) throws ParseException {
+            DateFormat outputFormat = new SimpleDateFormat("MM/dd/yy", Locale.US);
+            DateFormat inputFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US);
+            Date formattedDate = inputFormat.parse(unformattedDate);
+            return outputFormat.format(formattedDate);
         }
 
         public void onClick(View v) {
             int position = getAdapterPosition();
             if (position != RecyclerView.NO_POSITION) {
+                Event event = events.get(position);
                 Intent intent = new Intent(context, EventDetailsActivity.class);
+                intent.putExtra(Event.class.getSimpleName(), Parcels.wrap(event));
                 context.startActivity(intent);
             }
         }

--- a/app/src/main/java/com/example/event_finder_capstone/EventsAdapter.java
+++ b/app/src/main/java/com/example/event_finder_capstone/EventsAdapter.java
@@ -1,6 +1,7 @@
 package com.example.event_finder_capstone;
 
 import android.content.Context;
+import android.content.Intent;
 import android.icu.text.SimpleDateFormat;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -45,7 +46,7 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
         return events.size();
     }
 
-    public class ViewHolder extends RecyclerView.ViewHolder {
+    public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
 
         ImageView ivEventPhoto;
         TextView tvEventTitle;
@@ -60,6 +61,7 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
             tvEventDescription = itemView.findViewById(R.id.tvEventDescription);
             tvStartDate = itemView.findViewById(R.id.tvStartDate);
             tvEndDate = itemView.findViewById(R.id.tvEndDate);
+            itemView.setOnClickListener(this);
         }
 
         public void bind(Event event) {
@@ -75,5 +77,14 @@ public class EventsAdapter extends RecyclerView.Adapter<EventsAdapter.ViewHolder
             SimpleDateFormat formatter = new SimpleDateFormat("MM/dd/yy");
             return formatter.format(date);
         }
+
+        public void onClick(View v) {
+            int position = getAdapterPosition();
+            if (position != RecyclerView.NO_POSITION) {
+                Intent intent = new Intent(context, EventDetailsActivity.class);
+                context.startActivity(intent);
+            }
+        }
     }
+
 }

--- a/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.event_finder_capstone;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -92,11 +91,12 @@ public class MainActivity extends AppCompatActivity {
         return res;
     }
 
-    private void populateEventInfo(int  i, Event event, JsonObject temp) {
+    private void populateEventInfo(int i, Event event, JsonObject temp) {
         event.setName(temp.get("name").getAsString());
         event.setDescription(temp.get("description").getAsString());
         event.setImageUrl(temp.get("image_url").getAsString());
         event.setTimeStart(temp.get("time_start").getAsString());
+        event.setId(temp.get("id").getAsString());
         event.setEventSiteUrl(temp.get("event_site_url").getAsString());
         checkAndSetEventEndTime(event, temp);
         checkAndSetEventCost(event, temp);
@@ -105,7 +105,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void checkAndSetEventCost(Event event, JsonObject temp) {
         if (!String.valueOf(temp.get("cost")).equals("null")) {
-            event.setCost("$" + temp.get("cost").getAsString() +"0");
+            event.setCost("$" + temp.get("cost").getAsString() + "0");
         } else {
             event.setCost("N/A");
         }

--- a/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
@@ -97,18 +97,32 @@ public class MainActivity extends AppCompatActivity {
         event.setDescription(temp.get("description").getAsString());
         event.setImageUrl(temp.get("image_url").getAsString());
         event.setTimeStart(temp.get("time_start").getAsString());
-        if (!String.valueOf(temp.get("time_end")).equals("null")) {
-            event.setTimeEnd(temp.get("time_end").getAsString());
-        } else {
-            event.setTimeEnd(temp.get("time_start").getAsString());
-        }
+        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
+        checkAndSetEventEndTime(event, temp);
+        checkAndSetEventCost(event, temp);
+        formatAndSetEventLocation(temp, event);
+    }
+
+    private void checkAndSetEventCost(Event event, JsonObject temp) {
         if (!String.valueOf(temp.get("cost")).equals("null")) {
             event.setCost("$" + temp.get("cost").getAsString());
         } else {
             event.setCost("N/A");
         }
-        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
-        event.setLocation(temp.get("location").getAsJsonObject().get("display_address").toString());
+    }
+
+    private void checkAndSetEventEndTime(Event event, JsonObject temp) {
+        if (!String.valueOf(temp.get("time_end")).equals("null")) {
+            event.setTimeEnd(temp.get("time_end").getAsString());
+        } else {
+            event.setTimeEnd(temp.get("time_start").getAsString());
+        }
+    }
+
+    private void formatAndSetEventLocation(JsonObject temp, Event event) {
+        String formattedLocation = temp.get("location").getAsJsonObject().get("display_address").toString();
+        formattedLocation = formattedLocation.replaceAll("[\\[\\]\"\"]", " ");
+        event.setLocation(formattedLocation);
     }
 
     @Override

--- a/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
@@ -105,7 +105,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void checkAndSetEventCost(Event event, JsonObject temp) {
         if (!String.valueOf(temp.get("cost")).equals("null")) {
-            event.setCost("$" + temp.get("cost").getAsString());
+            event.setCost("$" + temp.get("cost").getAsString() +"0");
         } else {
             event.setCost("N/A");
         }

--- a/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
@@ -2,6 +2,7 @@ package com.example.event_finder_capstone;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.Toast;
@@ -25,6 +26,7 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class MainActivity extends AppCompatActivity {
+    private static final String TAG = "MainActivity";
     RecyclerView rvEvents;
     private List<Event> eventsList = new ArrayList<>();
     private EventsAdapter eventsAdapter;
@@ -84,13 +86,13 @@ public class MainActivity extends AppCompatActivity {
         for (int i = 0; i < events.size(); i++) {
             JsonObject temp = (JsonObject) events.get(i);
             Event event = new Event();
-            populateEventInfo(event, temp);
+            populateEventInfo(i, event, temp);
             res.add(event);
         }
         return res;
     }
 
-    private void populateEventInfo(Event event, JsonObject temp) {
+    private void populateEventInfo(int  i, Event event, JsonObject temp) {
         event.setName(temp.get("name").getAsString());
         event.setDescription(temp.get("description").getAsString());
         event.setImageUrl(temp.get("image_url").getAsString());
@@ -100,6 +102,13 @@ public class MainActivity extends AppCompatActivity {
         } else {
             event.setTimeEnd(temp.get("time_start").getAsString());
         }
+        if (!String.valueOf(temp.get("cost")).equals("null")) {
+            event.setCost("$" + temp.get("cost").getAsString());
+        } else {
+            event.setCost("N/A");
+        }
+        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
+        event.setLocation(temp.get("location").getAsJsonObject().get("display_address").toString());
     }
 
     @Override

--- a/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/MainActivity.java
@@ -47,7 +47,7 @@ public class MainActivity extends AppCompatActivity {
         String eventSearchRegion = "en_US";
         Long eventSearchRadiusFromUser = 40000L;
         String numberOfEventsToRetrieve = "10";
-        Long upcomingEventsOnly =  (System.currentTimeMillis() / 1000L);
+        Long upcomingEventsOnly = (System.currentTimeMillis() / 1000L);
         RetrofitClient.getInstance().getYelpAPI().getEvents(eventSearchRegion,
                 numberOfEventsToRetrieve,
                 upcomingEventsOnly,
@@ -84,13 +84,22 @@ public class MainActivity extends AppCompatActivity {
         for (int i = 0; i < events.size(); i++) {
             JsonObject temp = (JsonObject) events.get(i);
             Event event = new Event();
-            event.setName(temp.get("name").getAsString());
-            event.setDescription(temp.get("description").getAsString());
-            event.setImageUrl(temp.get("image_url").getAsString());
-            event.setTimeStart(temp.get("time_start").getAsString());
+            populateEventInfo(event, temp);
             res.add(event);
         }
         return res;
+    }
+
+    private void populateEventInfo(Event event, JsonObject temp) {
+        event.setName(temp.get("name").getAsString());
+        event.setDescription(temp.get("description").getAsString());
+        event.setImageUrl(temp.get("image_url").getAsString());
+        event.setTimeStart(temp.get("time_start").getAsString());
+        if (!String.valueOf(temp.get("time_end")).equals("null")) {
+            event.setTimeEnd(temp.get("time_end").getAsString());
+        } else {
+            event.setTimeEnd(temp.get("time_start").getAsString());
+        }
     }
 
     @Override

--- a/app/src/main/java/com/example/event_finder_capstone/ParseApplication.java
+++ b/app/src/main/java/com/example/event_finder_capstone/ParseApplication.java
@@ -2,7 +2,9 @@ package com.example.event_finder_capstone;
 
 import android.app.Application;
 
+import com.example.event_finder_capstone.models.Photo;
 import com.parse.Parse;
+import com.parse.ParseObject;
 
 public class ParseApplication extends Application {
 
@@ -12,6 +14,8 @@ public class ParseApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        ParseObject.registerSubclass(Photo.class);
 
         Parse.initialize(new Parse.Configuration.Builder(this)
                 .applicationId(parse_app_id)

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAdapter.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAdapter.java
@@ -1,0 +1,62 @@
+package com.example.event_finder_capstone;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.example.event_finder_capstone.models.Photo;
+import com.parse.ParseFile;
+
+import java.util.List;
+
+public class PhotoAdapter extends RecyclerView.Adapter<PhotoAdapter.ViewHolder> {
+
+    private final Context context;
+    private final List<Photo> photos;
+
+    public PhotoAdapter(Context context, List<Photo> photos) {
+        this.context = context;
+        this.photos = photos;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(context).inflate(R.layout.item_photo, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        Photo post = photos.get(position);
+        holder.bind(post);
+    }
+
+    @Override
+    public int getItemCount() {
+        return photos.size();
+    }
+
+    public class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final ImageView ivAlbumPhotoItem;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            ivAlbumPhotoItem = itemView.findViewById(R.id.ivAlbumPhotoItem);
+        }
+
+        public void bind(Photo post) {
+            ParseFile image = post.getImage();
+            if (image != null) {
+                Glide.with(context).load(image.getUrl()).into(ivAlbumPhotoItem);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -1,0 +1,15 @@
+package com.example.event_finder_capstone;
+
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class PhotoAlbumActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_photo_album);
+
+    }
+}

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -4,14 +4,10 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.Button;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
-import com.parse.ParseUser;
 
 public class PhotoAlbumActivity extends AppCompatActivity {
 

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -1,18 +1,14 @@
 package com.example.event_finder_capstone;
 
-import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.GridView;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.GridLayoutManager;
-import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.event_finder_capstone.models.Event;
@@ -30,15 +26,18 @@ public class PhotoAlbumActivity extends AppCompatActivity {
 
     private static final String TAG = "PhotoAlbumActivity";
     private static final int POST_LIMIT = 20;
-    Event event;
-    RecyclerView rvPhotos;
     protected PhotoAdapter photo_adapter;
     protected List<Photo> allPhotos;
+    Event event;
+    RecyclerView rvPhotos;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo_album);
+
+        event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+        getSupportActionBar().setTitle("Photos from " + event.getName());
 
         rvPhotos = findViewById(R.id.rvPhotos);
         allPhotos = new ArrayList<>();

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -1,21 +1,28 @@
 package com.example.event_finder_capstone;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.example.event_finder_capstone.models.Event;
+
+import org.parceler.Parcels;
+
 public class PhotoAlbumActivity extends AppCompatActivity {
+
+    private static final String TAG = "PhotoAlbumActivity";
+    Context context;
+    Event event;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo_album);
-
     }
 
     @Override
@@ -33,10 +40,11 @@ public class PhotoAlbumActivity extends AppCompatActivity {
     }
 
     void onAddImageButton() {
-        Toast.makeText(PhotoAlbumActivity.this, "Making new post!", Toast.LENGTH_LONG).show();
-        Intent i = new Intent(this, AddPhotoActivity.class);
-        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        startActivity(i);
+        Intent intent = new Intent(PhotoAlbumActivity.this, AddPhotoActivity.class);
+        event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+        intent.putExtra(Event.class.getSimpleName(), Parcels.wrap(event));
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -3,26 +3,71 @@ package com.example.event_finder_capstone;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.GridView;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.event_finder_capstone.models.Event;
+import com.example.event_finder_capstone.models.Photo;
+import com.parse.FindCallback;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
 
 import org.parceler.Parcels;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PhotoAlbumActivity extends AppCompatActivity {
 
     private static final String TAG = "PhotoAlbumActivity";
-    Context context;
+    private static final int POST_LIMIT = 20;
     Event event;
+    RecyclerView rvPhotos;
+    protected PhotoAdapter photo_adapter;
+    protected List<Photo> allPhotos;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo_album);
+
+        rvPhotos = findViewById(R.id.rvPhotos);
+        allPhotos = new ArrayList<>();
+        photo_adapter = new PhotoAdapter(this, allPhotos);
+        rvPhotos.setAdapter(photo_adapter);
+        GridLayoutManager gridLayoutManager = new GridLayoutManager(this, 2);
+        rvPhotos.setLayoutManager(gridLayoutManager);
+        event = Parcels.unwrap(getIntent().getParcelableExtra(Event.class.getSimpleName()));
+        queryPhotos(event.getId());
+    }
+
+    private void queryPhotos(String eventId) {
+        ParseQuery<Photo> query = ParseQuery.getQuery(Photo.class);
+        query.whereEqualTo(Photo.KEY_EVENT_ID, eventId);
+        query.include(Photo.KEY_USER);
+        query.include(Photo.KEY_EVENT_ID);
+        query.setLimit(POST_LIMIT);
+        query.addDescendingOrder("createdAt");
+        query.findInBackground(new FindCallback<Photo>() {
+            @Override
+            public void done(List<Photo> photos, ParseException e) {
+                if (e != null) {
+                    Toast.makeText(PhotoAlbumActivity.this, "Failed to query posts", Toast.LENGTH_LONG).show();
+                    return;
+                }
+                allPhotos.addAll(photos);
+                photo_adapter.notifyDataSetChanged();
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
+++ b/app/src/main/java/com/example/event_finder_capstone/PhotoAlbumActivity.java
@@ -1,15 +1,46 @@
 package com.example.event_finder_capstone;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.parse.ParseUser;
+
 public class PhotoAlbumActivity extends AppCompatActivity {
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_photo_album);
 
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.add_photo, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.btnAddPhoto) {
+            onAddImageButton();
+        }
+        return true;
+    }
+
+    void onAddImageButton() {
+        Toast.makeText(PhotoAlbumActivity.this, "Making new post!", Toast.LENGTH_LONG).show();
+        Intent i = new Intent(this, AddPhotoActivity.class);
+        i.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(i);
     }
 }

--- a/app/src/main/java/com/example/event_finder_capstone/models/Event.java
+++ b/app/src/main/java/com/example/event_finder_capstone/models/Event.java
@@ -1,13 +1,9 @@
 package com.example.event_finder_capstone.models;
 
-import android.location.Location;
-
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 import org.parceler.Parcel;
-
-import java.text.DecimalFormat;
 
 import javax.annotation.Generated;
 
@@ -75,6 +71,7 @@ public class Event {
     @SerializedName("business_id")
     @Expose
     private String businessId;
+
     public Event() {
     }
 
@@ -127,11 +124,11 @@ public class Event {
     }
 
     public String getId() {
-        return id;
+        return (String) id;
     }
 
     public void setId(String id) {
-        this.id = id;
+        this.id = (String) id;
     }
 
     public String getImageUrl() {

--- a/app/src/main/java/com/example/event_finder_capstone/models/Event.java
+++ b/app/src/main/java/com/example/event_finder_capstone/models/Event.java
@@ -7,6 +7,8 @@ import com.google.gson.annotations.SerializedName;
 
 import org.parceler.Parcel;
 
+import java.text.DecimalFormat;
+
 import javax.annotation.Generated;
 
 @Parcel(analyze = {Event.class})
@@ -19,13 +21,12 @@ public class Event {
     @SerializedName("category")
     @Expose
     private String category;
-    // TODO: Figure out how to have parcels take in objects
-//    @SerializedName("cost")
-//    @Expose
-//    private Object cost;
-//    @SerializedName("cost_max")
-//    @Expose
-//    private Object costMax;
+    @SerializedName("cost")
+    @Expose
+    private String cost;
+    @SerializedName("cost_max")
+    @Expose
+    private String costMax;
     @SerializedName("description")
     @Expose
     private String description;
@@ -70,7 +71,7 @@ public class Event {
     private String timeStart;
     @SerializedName("location")
     @Expose
-    private Location location;
+    private String location;
     @SerializedName("business_id")
     @Expose
     private String businessId;
@@ -92,22 +93,22 @@ public class Event {
     public void setCategory(String category) {
         this.category = category;
     }
-//
-//    public Object getCost() {
-//        return cost;
-//    }
-//
-//    public void setCost(Object cost) {
-//        this.cost = cost;
-//    }
-//
-//    public Object getCostMax() {
-//        return costMax;
-//    }
-//
-//    public void setCostMax(Object costMax) {
-//        this.costMax = costMax;
-//    }
+
+    public String getCost() {
+        return cost;
+    }
+
+    public void setCost(String cost) {
+        this.cost = (String) cost;
+    }
+
+    public String getCostMax() {
+        return costMax;
+    }
+
+    public void setCostMax(String costMax) {
+        this.costMax = (String) costMax;
+    }
 
     public String getDescription() {
         return description;
@@ -221,11 +222,11 @@ public class Event {
         this.timeStart = timeStart;
     }
 
-    public Location getLocation() {
-        return location;
+    public String getLocation() {
+        return location.toString();
     }
 
-    public void setLocation(Location location) {
+    public void setLocation(String location) {
         this.location = location;
     }
 

--- a/app/src/main/java/com/example/event_finder_capstone/models/Event.java
+++ b/app/src/main/java/com/example/event_finder_capstone/models/Event.java
@@ -5,22 +5,27 @@ import android.location.Location;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
+import org.parceler.Parcel;
+
 import javax.annotation.Generated;
 
+@Parcel(analyze = {Event.class})
 @Generated("jsonschema2pojo")
 public class Event {
+
     @SerializedName("attending_count")
     @Expose
     private int attendingCount;
     @SerializedName("category")
     @Expose
     private String category;
-    @SerializedName("cost")
-    @Expose
-    private Object cost;
-    @SerializedName("cost_max")
-    @Expose
-    private Object costMax;
+    // TODO: Figure out how to have parcels take in objects
+//    @SerializedName("cost")
+//    @Expose
+//    private Object cost;
+//    @SerializedName("cost_max")
+//    @Expose
+//    private Object costMax;
     @SerializedName("description")
     @Expose
     private String description;
@@ -69,6 +74,8 @@ public class Event {
     @SerializedName("business_id")
     @Expose
     private String businessId;
+    public Event() {
+    }
 
     public int getAttendingCount() {
         return attendingCount;
@@ -85,22 +92,22 @@ public class Event {
     public void setCategory(String category) {
         this.category = category;
     }
-
-    public Object getCost() {
-        return cost;
-    }
-
-    public void setCost(Object cost) {
-        this.cost = cost;
-    }
-
-    public Object getCostMax() {
-        return costMax;
-    }
-
-    public void setCostMax(Object costMax) {
-        this.costMax = costMax;
-    }
+//
+//    public Object getCost() {
+//        return cost;
+//    }
+//
+//    public void setCost(Object cost) {
+//        this.cost = cost;
+//    }
+//
+//    public Object getCostMax() {
+//        return costMax;
+//    }
+//
+//    public void setCostMax(Object costMax) {
+//        this.costMax = costMax;
+//    }
 
     public String getDescription() {
         return description;

--- a/app/src/main/java/com/example/event_finder_capstone/models/Photo.java
+++ b/app/src/main/java/com/example/event_finder_capstone/models/Photo.java
@@ -1,0 +1,47 @@
+package com.example.event_finder_capstone.models;
+
+import com.parse.ParseClassName;
+import com.parse.ParseFile;
+import com.parse.ParseObject;
+import com.parse.ParseUser;
+
+@ParseClassName("Photo")
+public class Photo extends ParseObject {
+    public static final String KEY_DESCRIPTION = "description";
+    public static final String KEY_IMAGE = "image";
+    public static final String KEY_USER = "user";
+    public static final String KEY_EVENT_ID = "eventId";
+
+    public String getDescription() {
+        return getString(KEY_DESCRIPTION);
+    }
+
+    public void setDescription(String description) {
+        put(KEY_DESCRIPTION, description);
+    }
+
+    public ParseFile getImage() {
+        return getParseFile(KEY_IMAGE);
+    }
+
+    public void setImage(ParseFile parseFile) {
+        put(KEY_IMAGE, parseFile);
+    }
+
+    public ParseUser getUser() {
+        return getParseUser(KEY_USER);
+    }
+
+    public void setUser(ParseUser user) {
+        put(KEY_USER, user);
+    }
+
+    public String getEventId() {
+        return getString(KEY_EVENT_ID);
+    }
+
+    public void setEventId(String eventId) {
+        put(KEY_EVENT_ID, eventId);
+    }
+
+}

--- a/app/src/main/res/layout/activity_add_photo.xml
+++ b/app/src/main/res/layout/activity_add_photo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_add_photo.xml
+++ b/app/src/main/res/layout/activity_add_photo.xml
@@ -20,8 +20,8 @@
         android:layout_height="354dp"
         android:layout_marginTop="16dp"
         android:background="@color/black"
-        tools:srcCompat="@tools:sample/avatars"
-        android:contentDescription="@string/image" />
+        android:contentDescription="@string/image"
+        tools:srcCompat="@tools:sample/avatars" />
 
     <EditText
         android:id="@+id/etDescription"

--- a/app/src/main/res/layout/activity_add_photo.xml
+++ b/app/src/main/res/layout/activity_add_photo.xml
@@ -1,6 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="16dp">
+
+    <Button
+        android:id="@+id/btnCaptureImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/etDescription"
+        android:layout_marginStart="60dp"
+        android:layout_marginTop="23dp"
+        android:text="@string/add_photo" />
+
+    <ImageView
+        android:id="@+id/ivPostImage"
+        android:layout_width="match_parent"
+        android:layout_height="354dp"
+        android:layout_marginTop="16dp"
+        android:background="@color/black"
+        tools:srcCompat="@tools:sample/avatars"
+        android:contentDescription="@string/image" />
+
+    <EditText
+        android:id="@+id/etDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivPostImage"
+        android:layout_marginTop="15dp"
+        android:autofillHints=""
+        android:ems="10"
+        android:hint="@string/add_your_caption_here"
+        android:inputType="textPersonName"
+        android:minHeight="48dp"
+        android:textColorHint="#757575" />
+
+    <Button
+        android:id="@+id/btnSubmit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/etDescription"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="23dp"
+        android:layout_toEndOf="@+id/btnCaptureImage"
+        android:text="@string/submit" />
+
+    <ProgressBar
+        android:id="@+id/pbLoading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/btnSubmit"
+        android:layout_marginStart="165dp"
+        android:layout_marginTop="13dp"
+        android:visibility="invisible" />
+
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="16dp">
+
+    <TextView
+        android:id="@+id/tvEventDetailsTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
+        android:layout_marginTop="0dp"
+        android:text="The Great Cookout"
+        android:textSize="25sp"
+        tools:layout_editor_absoluteX="69dp"
+        tools:layout_editor_absoluteY="36dp" />
+
+    <ImageView
+        android:id="@+id/ivEventsDetailsImage"
+        android:layout_width="match_parent"
+        android:layout_height="260dp"
+        android:layout_below="@+id/tvEventDetailsTitle"
+        android:layout_marginTop="8dp"
+        android:scaleType="centerCrop"
+        tools:srcCompat="@tools:sample/avatars" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsDateHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginTop="19dp"
+        android:text="Event Dates: "
+        android:textSize="16sp"
+        android:textStyle="bold"
+        tools:text="Event Dates:" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsStartDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="19dp"
+        android:layout_toEndOf="@+id/tvEventDetailsDateHeader"
+        android:textSize="16sp"
+        tools:text="09/1/22" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsEndDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="19dp"
+        android:layout_toEndOf="@+id/tvEventDetailsTo"
+        android:textSize="16sp"
+        tools:text="09/02/22" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsTo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="19dp"
+        android:layout_toEndOf="@+id/tvEventDetailsStartDate"
+        android:text="@string/to"
+        android:textSize="16sp"
+        tools:text="@string/to" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsDescription"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsDateHeader"
+        android:layout_marginTop="11dp"
+        tools:text="Insert the awesome event description here. More details and whatnot go here. Inserting more text because descriptions are long." />
+
+    <TextView
+        android:id="@+id/tvEventDetailsAddress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsDescription"
+        android:layout_marginStart="7dp"
+        android:layout_marginTop="13dp"
+        android:layout_toEndOf="@+id/tvEventDetailsAddressHeader"
+        android:textSize="14sp"
+        tools:text="1 Hacker Way, Menlo Park, CA 94025" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsSite"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsAddress"
+        android:layout_marginStart="7dp"
+        android:layout_marginTop="13dp"
+        android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
+        android:textSize="14sp"
+        android:linksClickable="true"
+        tools:text="www.yelp.com" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsCostHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="19dp"
+        android:layout_toEndOf="@+id/tvEventDetailsEndDate"
+        android:text="Cost:"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        tools:text="Cost:" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsCost"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ivEventsDetailsImage"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="19dp"
+        android:layout_toEndOf="@+id/tvEventDetailsCostHeader"
+        android:textSize="16sp"
+        tools:text="$2" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsAddressHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsDescription"
+        android:layout_marginTop="11dp"
+        android:text="Location:"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        tools:text="Location:" />
+
+    <TextView
+        android:id="@+id/tvEventDetailsSiteHeader"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsAddressHeader"
+        android:layout_marginTop="11dp"
+        android:text="Event Site:"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        tools:text="Event Site:" />
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -93,9 +93,9 @@
     <TextView
         android:id="@+id/tvEventDetailsSite"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="24dp"
         android:layout_below="@+id/tvEventDetailsAddress"
-        android:layout_marginStart="7dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="11dp"
         android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
         android:minHeight="48dp"
@@ -143,11 +143,19 @@
         android:id="@+id/tvEventDetailsSiteHeader"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/tvEventDetailsAddressHeader"
+        android:layout_below="@+id/tvEventDetailsAddress"
         android:layout_marginTop="11dp"
         android:text="@string/event_site"
         android:textSize="16sp"
         android:textStyle="bold"
         tools:text="Event Site:" />
+
+    <Button
+        android:id="@+id/btnPhotoAlbum"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvEventDetailsSite"
+        android:layout_marginTop="11dp"
+        android:text="@string/photo_album" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -12,10 +12,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="0dp"
         android:layout_marginTop="0dp"
-        android:text="The Great Cookout"
         android:textSize="25sp"
         tools:layout_editor_absoluteX="69dp"
-        tools:layout_editor_absoluteY="36dp" />
+        tools:layout_editor_absoluteY="36dp"
+        tools:text="The Great Cookout" />
 
     <ImageView
         android:id="@+id/ivEventsDetailsImage"
@@ -24,7 +24,8 @@
         android:layout_below="@+id/tvEventDetailsTitle"
         android:layout_marginTop="8dp"
         android:scaleType="centerCrop"
-        tools:srcCompat="@tools:sample/avatars" />
+        tools:srcCompat="@tools:sample/avatars"
+        android:contentDescription="@string/todo" />
 
     <TextView
         android:id="@+id/tvEventDetailsDateHeader"
@@ -32,7 +33,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
         android:layout_marginTop="19dp"
-        android:text="Event Dates: "
+        android:text="@string/event_dates"
         android:textSize="16sp"
         android:textStyle="bold"
         tools:text="Event Dates:" />
@@ -110,7 +111,7 @@
         android:layout_marginStart="20dp"
         android:layout_marginTop="19dp"
         android:layout_toEndOf="@+id/tvEventDetailsEndDate"
-        android:text="Cost:"
+        android:text="@string/cost"
         android:textSize="16sp"
         android:textStyle="bold"
         tools:text="Cost:" />
@@ -132,7 +133,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvEventDetailsDescription"
         android:layout_marginTop="11dp"
-        android:text="Location:"
+        android:text="@string/location"
         android:textSize="16sp"
         android:textStyle="bold"
         tools:text="Location:" />
@@ -143,7 +144,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvEventDetailsAddressHeader"
         android:layout_marginTop="11dp"
-        android:text="Event Site:"
+        android:text="@string/event_site"
         android:textSize="16sp"
         android:textStyle="bold"
         tools:text="Event Site:" />

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,9 +22,9 @@
         android:layout_height="260dp"
         android:layout_below="@+id/tvEventDetailsTitle"
         android:layout_marginTop="8dp"
+        android:contentDescription="@string/todo"
         android:scaleType="centerCrop"
-        tools:srcCompat="@tools:sample/avatars"
-        android:contentDescription="@string/todo" />
+        tools:srcCompat="@tools:sample/avatars" />
 
     <TextView
         android:id="@+id/tvEventDetailsDateHeader"
@@ -99,6 +98,7 @@
         android:layout_marginStart="7dp"
         android:layout_marginTop="13dp"
         android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
+        android:autoLink="all"
         android:linksClickable="true"
         android:textSize="14sp"
         tools:text="www.yelp.com" />
@@ -121,7 +121,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
-        android:layout_marginStart="4dp"
+        android:layout_marginStart="2dp"
         android:layout_marginTop="19dp"
         android:layout_toEndOf="@+id/tvEventDetailsCostHeader"
         android:textSize="16sp"

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -42,10 +42,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="19dp"
+        android:layout_marginStart="2dp"
+        android:layout_marginTop="20dp"
         android:layout_toEndOf="@+id/tvEventDetailsDateHeader"
-        android:textSize="16sp"
+        android:textSize="14sp"
         tools:text="09/1/22" />
 
     <TextView
@@ -54,9 +54,9 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
         android:layout_marginStart="5dp"
-        android:layout_marginTop="19dp"
+        android:layout_marginTop="20dp"
         android:layout_toEndOf="@+id/tvEventDetailsTo"
-        android:textSize="16sp"
+        android:textSize="14sp"
         tools:text="09/02/22" />
 
     <TextView
@@ -65,10 +65,10 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
         android:layout_marginStart="5dp"
-        android:layout_marginTop="19dp"
+        android:layout_marginTop="20dp"
         android:layout_toEndOf="@+id/tvEventDetailsStartDate"
         android:text="@string/to"
-        android:textSize="16sp"
+        android:textSize="14sp"
         tools:text="@string/to" />
 
     <TextView
@@ -109,7 +109,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
-        android:layout_marginStart="11dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="19dp"
         android:layout_toEndOf="@+id/tvEventDetailsEndDate"
         android:text="@string/cost"
@@ -123,9 +123,9 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
         android:layout_marginStart="2dp"
-        android:layout_marginTop="19dp"
+        android:layout_marginTop="20dp"
         android:layout_toEndOf="@+id/tvEventDetailsCostHeader"
-        android:textSize="16sp"
+        android:textSize="14sp"
         tools:text="$2" />
 
     <TextView

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -98,8 +98,6 @@
         android:layout_marginStart="7dp"
         android:layout_marginTop="11dp"
         android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
-        android:autoLink="all"
-        android:linksClickable="true"
         android:minHeight="48dp"
         android:textColor="#00838F"
         android:textSize="14sp"

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -99,8 +99,8 @@
         android:layout_marginStart="7dp"
         android:layout_marginTop="13dp"
         android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
-        android:textSize="14sp"
         android:linksClickable="true"
+        android:textSize="14sp"
         tools:text="www.yelp.com" />
 
     <TextView
@@ -108,7 +108,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/ivEventsDetailsImage"
-        android:layout_marginStart="20dp"
+        android:layout_marginStart="11dp"
         android:layout_marginTop="19dp"
         android:layout_toEndOf="@+id/tvEventDetailsEndDate"
         android:text="@string/cost"

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -96,11 +96,14 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvEventDetailsAddress"
         android:layout_marginStart="7dp"
-        android:layout_marginTop="13dp"
+        android:layout_marginTop="11dp"
         android:layout_toEndOf="@+id/tvEventDetailsSiteHeader"
         android:autoLink="all"
         android:linksClickable="true"
+        android:minHeight="48dp"
+        android:textColor="#00838F"
         android:textSize="14sp"
+        tools:ignore="TextContrastCheck"
         tools:text="www.yelp.com" />
 
     <TextView

--- a/app/src/main/res/layout/activity_photo_album.xml
+++ b/app/src/main/res/layout/activity_photo_album.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_photo_album.xml
+++ b/app/src/main/res/layout/activity_photo_album.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_margin="16dp"
+    android:orientation="vertical"
+    tools:context=".PhotoAlbumActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvPhotos"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_centerInParent="true"
+        android:padding="8dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_event.xml
+++ b/app/src/main/res/layout/item_event.xml
@@ -12,8 +12,8 @@
         android:layout_height="90dp"
         android:layout_marginStart="5dp"
         android:layout_marginTop="0dp"
-        tools:srcCompat="@tools:sample/avatars"
-        android:contentDescription="TODO" />
+        android:scaleType="centerCrop"
+        tools:srcCompat="@tools:sample/avatars" />
 
     <TextView
         android:id="@+id/tvEventTitle"

--- a/app/src/main/res/layout/item_photo.xml
+++ b/app/src/main/res/layout/item_photo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="120dp"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_margin="5dp"
+    app:cardCornerRadius="5dp"
+    app:cardElevation="5dp">
+
+    <ImageView
+        android:id="@+id/ivAlbumPhotoItem"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop"
+        tools:srcCompat="@tools:sample/avatars" />
+
+</RelativeLayout>

--- a/app/src/main/res/menu/add_photo.xml
+++ b/app/src/main/res/menu/add_photo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/btnAddPhoto"
+        android:icon="@android:drawable/ic_menu_camera"
+        android:title="@string/add_photo"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,7 @@
     <string name="todo">TODO</string>
     <string name="photo_album">Photo Album</string>
     <string name="add_photo">Add Photo</string>
+    <string name="add_your_caption_here">Add your caption here!</string>
+    <string name="submit">Submit</string>
+    <string name="image">TODO</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="intent_host">events</string>
     <string name="to">to</string>
     <string name="event_dates">Event Dates:</string>
-    <string name="cost">Cost:</string>
+    <string name="cost">Cost: </string>
     <string name="location">Location:</string>
     <string name="event_site">Event Site:</string>
     <string name="todo">TODO</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,9 @@
     <string name="intent_scheme">oauth</string>
     <string name="intent_host">events</string>
     <string name="to">to</string>
+    <string name="event_dates">Event Dates:</string>
+    <string name="cost">Cost:</string>
+    <string name="location">Location:</string>
+    <string name="event_site">Event Site:</string>
+    <string name="todo">TODO</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="location">Location:</string>
     <string name="event_site">Event Site:</string>
     <string name="todo">TODO</string>
+    <string name="photo_album">Photo Album</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="event_site">Event Site:</string>
     <string name="todo">TODO</string>
     <string name="photo_album">Photo Album</string>
+    <string name="add_photo">Add Photo</string>
 </resources>

--- a/app/src/main/res/xml/photoprovider.xml
+++ b/app/src/main/res/xml/photoprovider.xml
@@ -1,0 +1,5 @@
+<paths>
+    <external-files-path
+        name="images"
+        path="Pictures" />
+</paths>


### PR DESCRIPTION
New stuff:

- User can upload (click on camera in menu) and view photos from each event in a grid layout in the photo album
- Changed titles on each screen

Notes:
- Description and photo are required to save post
- While adding a photo and saving it stores the user and a description, that is not going to be used until I work on a later user story where the user can click on a photo and see an animation of it growing as well as a display of the photo's description and who posted it

Screenshots of Add Photo and Photo Album Pages:

<img width="300" alt="Photo Album" src="https://user-images.githubusercontent.com/59234861/176317366-30f230da-a096-4e39-b138-df3c8c7e7903.png">

<img width="300" alt="Add Photo" src="https://user-images.githubusercontent.com/59234861/176317361-6b4626a0-f370-4a6e-a8c4-93ed94928e4b.png">