### PR TITLE
User can view their profile with their username and bookmarked events

### DIFF
--- a/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
+++ b/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
@@ -16,7 +16,6 @@ import com.capstone.event_finder.fragments.ExploreFragment;
 import com.capstone.event_finder.fragments.FeedFragment;
 import com.capstone.event_finder.fragments.ProfileFragment;
 import com.capstone.event_finder.interfaces.FeedFragmentInterface;
-import com.capstone.event_finder.interfaces.ProfileFragmentInterface;
 import com.capstone.event_finder.network.EventViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.parse.ParseUser;
@@ -24,7 +23,6 @@ import com.parse.ParseUser;
 public class MainActivity extends AppCompatActivity {
     private EventViewModel eventViewModel;
     private FeedFragmentInterface listener;
-    private ProfileFragmentInterface profileListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,17 +36,12 @@ public class MainActivity extends AppCompatActivity {
     public void setListener(FeedFragmentInterface listener) {
         this.listener = listener;
     }
-    public void setProfileListener(ProfileFragmentInterface profileListener) {
-        this.profileListener = profileListener;
-    }
-
 
     private void setUpBottomNavigation(FragmentManager fragmentManager) {
         Fragment feedFragment = new FeedFragment();
         Fragment exploreFragment = new ExploreFragment();
         Fragment profileFragment = new ProfileFragment();
         initialCallToEventApi((FeedFragmentInterface) feedFragment);
-        initialCallForBookmarks((ProfileFragmentInterface) profileFragment);
         BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
         bottomNavigationView.setOnItemSelectedListener(menuItem -> {
             Fragment fragment;
@@ -74,11 +67,6 @@ public class MainActivity extends AppCompatActivity {
     private void initialCallToEventApi(FeedFragmentInterface feedFragment) {
         setListener(feedFragment);
         listener.getAPIEvents();
-    }
-
-    private void initialCallForBookmarks (ProfileFragmentInterface profileFragment) {
-        setProfileListener(profileFragment);
-        //profileListener.getAndSetUserBookmarks();
     }
 
     @Override

--- a/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
+++ b/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
@@ -16,6 +16,7 @@ import com.capstone.event_finder.fragments.ExploreFragment;
 import com.capstone.event_finder.fragments.FeedFragment;
 import com.capstone.event_finder.fragments.ProfileFragment;
 import com.capstone.event_finder.interfaces.FeedFragmentInterface;
+import com.capstone.event_finder.interfaces.ProfileFragmentInterface;
 import com.capstone.event_finder.network.EventViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.parse.ParseUser;
@@ -23,6 +24,7 @@ import com.parse.ParseUser;
 public class MainActivity extends AppCompatActivity {
     private EventViewModel eventViewModel;
     private FeedFragmentInterface listener;
+    private ProfileFragmentInterface profileListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,12 +38,17 @@ public class MainActivity extends AppCompatActivity {
     public void setListener(FeedFragmentInterface listener) {
         this.listener = listener;
     }
+    public void setProfileListener(ProfileFragmentInterface profileListener) {
+        this.profileListener = profileListener;
+    }
+
 
     private void setUpBottomNavigation(FragmentManager fragmentManager) {
         Fragment feedFragment = new FeedFragment();
         Fragment exploreFragment = new ExploreFragment();
         Fragment profileFragment = new ProfileFragment();
         initialCallToEventApi((FeedFragmentInterface) feedFragment);
+        initialCallForBookmarks((ProfileFragmentInterface) profileFragment);
         BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
         bottomNavigationView.setOnItemSelectedListener(menuItem -> {
             Fragment fragment;
@@ -67,6 +74,11 @@ public class MainActivity extends AppCompatActivity {
     private void initialCallToEventApi(FeedFragmentInterface feedFragment) {
         setListener(feedFragment);
         listener.getAPIEvents();
+    }
+
+    private void initialCallForBookmarks (ProfileFragmentInterface profileFragment) {
+        setProfileListener(profileFragment);
+        //profileListener.getAndSetUserBookmarks();
     }
 
     @Override

--- a/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
+++ b/app/src/main/java/com/capstone/event_finder/activities/MainActivity.java
@@ -16,8 +16,11 @@ import com.capstone.event_finder.fragments.ExploreFragment;
 import com.capstone.event_finder.fragments.FeedFragment;
 import com.capstone.event_finder.fragments.ProfileFragment;
 import com.capstone.event_finder.interfaces.FeedFragmentInterface;
+import com.capstone.event_finder.models.Event;
 import com.capstone.event_finder.network.EventViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import com.parse.ParseUser;
 
 public class MainActivity extends AppCompatActivity {
@@ -63,6 +66,50 @@ public class MainActivity extends AppCompatActivity {
         });
         bottomNavigationView.setSelectedItemId(R.id.action_feed);
     }
+
+    public void populateEventInfo(Event event, JsonObject temp) {
+        event.setName(temp.get("name").getAsString());
+        event.setDescription(temp.get("description").getAsString());
+        event.setImageUrl(temp.get("image_url").getAsString());
+        event.setTimeStart(temp.get("time_start").getAsString());
+        event.setId(temp.get("id").getAsString());
+        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
+        event.setCategory(temp.get("category").getAsString());
+        checkAndSetEventEndTime(event, temp);
+        checkAndSetEventCost(event, temp);
+        formatAndSetEventLocation(temp, event);
+    }
+
+    private void checkAndSetEventCost(Event event, JsonObject temp) {
+        if (temp.get("cost").toString().matches("null")) {
+            event.setCost("N/A");
+        } else {
+            event.setCost("$" + temp.get("cost").getAsString() + "0");
+        }
+    }
+
+    private void checkAndSetEventEndTime(Event event, JsonObject temp) {
+        if (temp.get("time_end").toString().matches("null")) {
+            event.setTimeEnd(temp.get("time_start").getAsString());
+        } else {
+            event.setTimeEnd(temp.get("time_end").getAsString());
+        }
+    }
+
+    private void formatAndSetEventLocation(JsonObject temp, Event event) {
+        JsonArray formattedLocation = temp.getAsJsonObject("location").getAsJsonArray("display_address");
+        StringBuilder formattedLocationString = new StringBuilder();
+        for (int i = 0; i < formattedLocation.size(); i++) {
+            formattedLocationString.append(formattedLocation.get(i).getAsString()).append(" ");
+        }
+        event.setLocation(formattedLocationString.toString());
+    }
+
+
+
+
+
+
 
     private void initialCallToEventApi(FeedFragmentInterface feedFragment) {
         setListener(feedFragment);

--- a/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
@@ -1,6 +1,9 @@
 package com.capstone.event_finder.fragments;
 
+import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
+
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.capstone.event_finder.R;
+import com.capstone.event_finder.activities.MainActivity;
 import com.capstone.event_finder.adapters.EventsAdapter;
 import com.capstone.event_finder.interfaces.FeedFragmentInterface;
 import com.capstone.event_finder.models.Event;
@@ -140,47 +141,9 @@ public class FeedFragment extends Fragment implements FeedFragmentInterface {
         for (int i = 0; i < events.size(); i++) {
             JsonObject temp = (JsonObject) events.get(i);
             Event event = new Event();
-            populateEventInfo(event, temp);
+            ((MainActivity) getActivity()).populateEventInfo(event, temp);
             res.add(event);
         }
         return res;
-    }
-
-    private void populateEventInfo(Event event, JsonObject temp) {
-        event.setName(temp.get("name").getAsString());
-        event.setDescription(temp.get("description").getAsString());
-        event.setImageUrl(temp.get("image_url").getAsString());
-        event.setTimeStart(temp.get("time_start").getAsString());
-        event.setId(temp.get("id").getAsString());
-        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
-        event.setCategory(temp.get("category").getAsString());
-        checkAndSetEventEndTime(event, temp);
-        checkAndSetEventCost(event, temp);
-        formatAndSetEventLocation(temp, event);
-    }
-
-    private void checkAndSetEventCost(Event event, JsonObject temp) {
-        if (temp.get("cost").toString().matches("null")) {
-            event.setCost("N/A");
-        } else {
-            event.setCost("$" + temp.get("cost").getAsString() + "0");
-        }
-    }
-
-    private void checkAndSetEventEndTime(Event event, JsonObject temp) {
-        if (temp.get("time_end").toString().matches("null")) {
-            event.setTimeEnd(temp.get("time_start").getAsString());
-        } else {
-            event.setTimeEnd(temp.get("time_end").getAsString());
-        }
-    }
-
-    private void formatAndSetEventLocation(JsonObject temp, Event event) {
-        JsonArray formattedLocation = temp.getAsJsonObject("location").getAsJsonArray("display_address");
-        StringBuilder formattedLocationString = new StringBuilder();
-        for (int i = 0; i < formattedLocation.size(); i++) {
-            formattedLocationString.append(formattedLocation.get(i).getAsString()).append(" ");
-        }
-        event.setLocation(formattedLocationString.toString());
     }
 }

--- a/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
@@ -52,13 +52,13 @@ public class FeedFragment extends Fragment implements FeedFragmentInterface {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         eventViewModel = new ViewModelProvider(this).get(EventViewModel.class);
+        setUpRecyclerView(view);
         setUpSwipeRefresh(view);
         tryLocallyCaching();
     }
 
     private void setUpSwipeRefresh(@NonNull View view) {
         swipeContainer = view.findViewById(R.id.swipeContainer);
-        setUpRecyclerView(view);
         swipeContainer.setOnRefreshListener(() -> {
             Toast.makeText(getContext(), "Finding new events!", Toast.LENGTH_SHORT).show();
             getAPIEvents();

--- a/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
@@ -4,13 +4,19 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.capstone.event_finder.R;
+import com.parse.ParseUser;
+
+import org.w3c.dom.Text;
 
 public class ProfileFragment extends Fragment {
+
+    TextView tvProfileUsername;
 
     public ProfileFragment() {
     }
@@ -24,6 +30,9 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+
+        tvProfileUsername = view.findViewById(R.id.tvProfileUsername);
+        tvProfileUsername.setText(ParseUser.getCurrentUser().getUsername());
     }
 
 }

--- a/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
@@ -1,9 +1,6 @@
 package com.capstone.event_finder.fragments;
 
-import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
-
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.capstone.event_finder.R;
+import com.capstone.event_finder.activities.MainActivity;
 import com.capstone.event_finder.adapters.EventsAdapter;
 import com.capstone.event_finder.models.Bookmark;
 import com.capstone.event_finder.models.Event;
@@ -152,47 +153,9 @@ public class ProfileFragment extends Fragment {
         for (int i = 0; i < result.size(); i++) {
             JsonObject temp = (JsonObject) result.get(i);
             Event event = new Event();
-            populateEventInfo(event, temp);
+            ((MainActivity) getActivity()).populateEventInfo(event, temp);
             res.add(event);
         }
         return res;
-    }
-
-    private void populateEventInfo(Event event, JsonObject temp) {
-        event.setName(temp.get("name").getAsString());
-        event.setDescription(temp.get("description").getAsString());
-        event.setImageUrl(temp.get("image_url").getAsString());
-        event.setTimeStart(temp.get("time_start").getAsString());
-        event.setId(temp.get("id").getAsString());
-        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
-        event.setCategory(temp.get("category").getAsString());
-        checkAndSetEventEndTime(event, temp);
-        checkAndSetEventCost(event, temp);
-        formatAndSetEventLocation(temp, event);
-    }
-
-    private void checkAndSetEventCost(Event event, JsonObject temp) {
-        if (temp.get("cost").toString().matches("null")) {
-            event.setCost("N/A");
-        } else {
-            event.setCost("$" + temp.get("cost").getAsString() + "0");
-        }
-    }
-
-    private void checkAndSetEventEndTime(Event event, JsonObject temp) {
-        if (temp.get("time_end").toString().matches("null")) {
-            event.setTimeEnd(temp.get("time_start").getAsString());
-        } else {
-            event.setTimeEnd(temp.get("time_end").getAsString());
-        }
-    }
-
-    private void formatAndSetEventLocation(JsonObject temp, Event event) {
-        JsonArray formattedLocation = temp.getAsJsonObject("location").getAsJsonArray("display_address");
-        StringBuilder formattedLocationString = new StringBuilder();
-        for (int i = 0; i < formattedLocation.size(); i++) {
-            formattedLocationString.append(formattedLocation.get(i).getAsString()).append(" ");
-        }
-        event.setLocation(formattedLocationString.toString());
     }
 }

--- a/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
@@ -77,9 +77,7 @@ public class ProfileFragment extends Fragment {
 
     private void tryRetrieveEventInCache(String eventId, JsonArray allBookmarks) {
         eventViewModel.eventInCache(eventId).observe(getViewLifecycleOwner(), events -> {
-            Log.d(TAG, "checking if in cache " + events.toString());
             if (events.isEmpty()) {
-                Log.d(TAG, "calling api!");
                 lookupEventsAndSetEvents(eventId, allBookmarks);
             }
             bookmarkList.addAll(events);

--- a/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ProfileFragment.java
@@ -1,22 +1,51 @@
 package com.capstone.event_finder.fragments;
 
+import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
+
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.capstone.event_finder.R;
+import com.capstone.event_finder.adapters.EventsAdapter;
+import com.capstone.event_finder.models.Bookmark;
+import com.capstone.event_finder.models.Event;
+import com.capstone.event_finder.network.RetrofitClient;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.parse.FindCallback;
+import com.parse.ParseException;
+import com.parse.ParseQuery;
 import com.parse.ParseUser;
 
-import org.w3c.dom.Text;
+import org.json.JSONArray;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class ProfileFragment extends Fragment {
 
+    RecyclerView rvBookmarks;
     TextView tvProfileUsername;
+    EventsAdapter bookmarkAdapter;
+    JSONArray allBookmarks;
+    private List<Bookmark> userBookmarks = new ArrayList<Bookmark>();
+    private List<Event> bookmarkList = new ArrayList<>();
+    private ArrayList bookmarkIds = new ArrayList();
 
     public ProfileFragment() {
     }
@@ -30,9 +59,116 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
+        //setUpRecyclerView(view);
         tvProfileUsername = view.findViewById(R.id.tvProfileUsername);
+        rvBookmarks = view.findViewById(R.id.rvBookmarks);
         tvProfileUsername.setText(ParseUser.getCurrentUser().getUsername());
+        queryUserBookmarksFromParse();
+        //lookupEvent();
+    }
+
+    public void queryUserBookmarksFromParse(){
+        final int POST_LIMIT = 10;
+        ParseQuery<Bookmark> query = ParseQuery.getQuery(Bookmark.class);
+        query.whereEqualTo(Bookmark.KEY_USER, ParseUser.getCurrentUser());
+        query.setLimit(POST_LIMIT);
+        query.addDescendingOrder("createdAt");
+        query.findInBackground(new FindCallback<Bookmark>() {
+            @Override
+            public void done(List<Bookmark> bookmarks, ParseException e) {
+                if (e != null) {
+                    Toast.makeText(getContext(), "Failed to find bookmarks", Toast.LENGTH_LONG).show();
+                    return;
+                }
+                userBookmarks.addAll(bookmarks);
+                for (int i = 0; i < userBookmarks.size(); i++) {
+                    Bookmark bookmark = bookmarks.get(i);
+                    String bookmarkId = bookmark.getEventId();
+                    bookmarkIds.add(bookmarkId);
+                    Log.d(TAG, bookmarkIds.toString());
+                }
+            }
+        });
+    }
+
+    public void lookupEvent() {
+        RetrofitClient.getInstance().getYelpAPI().lookupEvent("oakland-saucy-oakland-restaurant-pop-up").enqueue(new Callback<JsonObject>() {
+            @Override
+            public void onResponse(@NonNull Call<JsonObject> call, @NonNull Response<JsonObject> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    JsonObject result = response.body();
+                    //Log.d(TAG, "This is the query: " + result.toString());
+                    Log.d(TAG, allBookmarks.toString());
+                    Toast.makeText(getContext(), "Query Success!", Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(getContext(), "Query Failed", Toast.LENGTH_SHORT).show();
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<JsonObject> call, @NonNull Throwable t) {
+                Toast.makeText(getContext(), "Failed to get events", Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    private void setUpRecyclerView(@NonNull View view) {
+        rvBookmarks = view.findViewById(R.id.rvBookmarks);
+        bookmarkList = new ArrayList<>();
+        bookmarkAdapter = new EventsAdapter(getContext(), bookmarkList);
+        rvBookmarks.setAdapter(bookmarkAdapter);
+        LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getContext());
+        rvBookmarks.setLayoutManager(linearLayoutManager);
+    }
+
+    private Collection<? extends Event> convertToList(JsonObject result) {
+        List<Event> res = new ArrayList<>();
+        JsonArray bookmarks = result.getAsJsonArray();
+        for (int i = 0; i < bookmarks.size(); i++) {
+            JsonObject temp = (JsonObject) bookmarks.get(i);
+            Event event = new Event();
+            populateEventInfo(event, temp);
+            res.add(event);
+        }
+        return res;
+    }
+
+    private void populateEventInfo(Event event, JsonObject temp) {
+        event.setName(temp.get("name").getAsString());
+        event.setDescription(temp.get("description").getAsString());
+        event.setImageUrl(temp.get("image_url").getAsString());
+        event.setTimeStart(temp.get("time_start").getAsString());
+        event.setId(temp.get("id").getAsString());
+        event.setEventSiteUrl(temp.get("event_site_url").getAsString());
+        event.setCategory(temp.get("category").getAsString());
+        checkAndSetEventEndTime(event, temp);
+        checkAndSetEventCost(event, temp);
+        formatAndSetEventLocation(temp, event);
+    }
+
+    private void checkAndSetEventCost(Event event, JsonObject temp) {
+        if (temp.get("cost").toString().matches("null")) {
+            event.setCost("N/A");
+        } else {
+            event.setCost("$" + temp.get("cost").getAsString() + "0");
+        }
+    }
+
+    private void checkAndSetEventEndTime(Event event, JsonObject temp) {
+        if (temp.get("time_end").toString().matches("null")) {
+            event.setTimeEnd(temp.get("time_start").getAsString());
+        } else {
+            event.setTimeEnd(temp.get("time_end").getAsString());
+        }
+    }
+
+    private void formatAndSetEventLocation(JsonObject temp, Event event) {
+        JsonArray formattedLocation = temp.getAsJsonObject("location").getAsJsonArray("display_address");
+        StringBuilder formattedLocationString = new StringBuilder();
+        for (int i = 0; i < formattedLocation.size(); i++) {
+            formattedLocationString.append(formattedLocation.get(i).getAsString()).append(" ");
+        }
+        event.setLocation(formattedLocationString.toString());
     }
 
 }

--- a/app/src/main/java/com/capstone/event_finder/interfaces/EventDao.java
+++ b/app/src/main/java/com/capstone/event_finder/interfaces/EventDao.java
@@ -21,4 +21,7 @@ public interface EventDao {
 
     @Query("DELETE FROM event_table")
     void deleteAllEvents();
+
+    @Query("SELECT * FROM event_table WHERE id == :eventId")
+    LiveData<List<Event>> eventInCache(String eventId);
 }

--- a/app/src/main/java/com/capstone/event_finder/interfaces/EventEndpointsInterface.java
+++ b/app/src/main/java/com/capstone/event_finder/interfaces/EventEndpointsInterface.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 public interface EventEndpointsInterface {
@@ -13,4 +14,7 @@ public interface EventEndpointsInterface {
                                @Query("start_date") Long start_date,
                                @Query("radius") Long radius,
                                @Query("location") String location);
+
+    @GET("events/{id}")
+    Call<JsonObject> lookupEvent(@Path("id") String id);
 }

--- a/app/src/main/java/com/capstone/event_finder/interfaces/ProfileFragmentInterface.java
+++ b/app/src/main/java/com/capstone/event_finder/interfaces/ProfileFragmentInterface.java
@@ -1,7 +1,0 @@
-package com.capstone.event_finder.interfaces;
-
-import com.google.gson.JsonArray;
-
-public interface ProfileFragmentInterface {
-    void getAndSetUserBookmarks(JsonArray allBookmarks);
-}

--- a/app/src/main/java/com/capstone/event_finder/interfaces/ProfileFragmentInterface.java
+++ b/app/src/main/java/com/capstone/event_finder/interfaces/ProfileFragmentInterface.java
@@ -1,0 +1,7 @@
+package com.capstone.event_finder.interfaces;
+
+import com.google.gson.JsonArray;
+
+public interface ProfileFragmentInterface {
+    void getAndSetUserBookmarks(JsonArray allBookmarks);
+}

--- a/app/src/main/java/com/capstone/event_finder/network/EventDatabase.java
+++ b/app/src/main/java/com/capstone/event_finder/network/EventDatabase.java
@@ -1,7 +1,6 @@
 package com.capstone.event_finder.network;
 
 import android.content.Context;
-import android.os.AsyncTask;
 
 import androidx.annotation.NonNull;
 import androidx.room.Database;
@@ -14,14 +13,13 @@ import com.capstone.event_finder.models.Event;
 
 @Database(entities = {Event.class}, version = 1)
 public abstract class EventDatabase extends RoomDatabase {
-    private static volatile EventDatabase instance;
     private static final RoomDatabase.Callback roomCallback = new RoomDatabase.Callback() {
         @Override
         public void onOpen(@NonNull SupportSQLiteDatabase db) {
             super.onOpen(db);
-            new populateDbAsyncTask(instance);
         }
     };
+    private static EventDatabase instance;
 
     public static synchronized EventDatabase getInstance(Context context) {
         if (instance == null) {
@@ -39,18 +37,4 @@ public abstract class EventDatabase extends RoomDatabase {
     }
 
     public abstract EventDao eventDao();
-
-    private static class populateDbAsyncTask extends AsyncTask<Void, Void, Void> {
-        private final EventDao eventDao;
-
-        public populateDbAsyncTask(EventDatabase eventDatabase) {
-            eventDao = eventDatabase.eventDao();
-        }
-
-        @Override
-        protected Void doInBackground(Void... voids) {
-            eventDao.deleteAllEvents();
-            return null;
-        }
-    }
 }

--- a/app/src/main/java/com/capstone/event_finder/network/EventRepository.java
+++ b/app/src/main/java/com/capstone/event_finder/network/EventRepository.java
@@ -14,11 +14,14 @@ public class EventRepository {
 
     public EventDao eventDao;
     public LiveData<List<Event>> getEvents;
+    public LiveData<List<Event>> eventInCache;
+
 
     public EventRepository(Application application) {
         EventDatabase eventDatabase = EventDatabase.getInstance(application);
         eventDao = eventDatabase.eventDao();
         getEvents = eventDao.getEvents();
+        eventInCache = eventDao.eventInCache("boston-sincere-engineer-and-covey");
     }
 
     public void insert(List<Event> events){
@@ -28,6 +31,8 @@ public class EventRepository {
     public LiveData<List<Event>> getEvents(){
         return getEvents;
     }
+
+    public LiveData<List<Event>> eventInCache(String eventId) {return eventInCache;}
 
     public void deleteAllEvents() {
         new DeleteAsyncTask(eventDao).execute();
@@ -62,4 +67,20 @@ public class EventRepository {
             return null;
         }
     }
+
+//    private static class EventAsyncTask extends AsyncTask<List<Event>,Void,Void> {
+//        private final EventDao eventDao;
+//        String eventId = "";
+//
+//        public EventAsyncTask(EventDao eventDao) {
+//            this.eventDao = eventDao;
+//        }
+//
+//        @SafeVarargs
+//        @Override
+//        protected final Void doInBackground(List<Event>... lists) {
+//            eventDao.eventInCache(eventId);
+//            return null;
+//        }
+//    }
 }

--- a/app/src/main/java/com/capstone/event_finder/network/EventRepository.java
+++ b/app/src/main/java/com/capstone/event_finder/network/EventRepository.java
@@ -21,7 +21,6 @@ public class EventRepository {
         EventDatabase eventDatabase = EventDatabase.getInstance(application);
         eventDao = eventDatabase.eventDao();
         getEvents = eventDao.getEvents();
-        eventInCache = eventDao.eventInCache("boston-sincere-engineer-and-covey");
     }
 
     public void insert(List<Event> events){
@@ -32,7 +31,8 @@ public class EventRepository {
         return getEvents;
     }
 
-    public LiveData<List<Event>> eventInCache(String eventId) {return eventInCache;}
+    public LiveData<List<Event>> eventInCache(String eventId) {return eventDao.eventInCache(eventId);
+        }
 
     public void deleteAllEvents() {
         new DeleteAsyncTask(eventDao).execute();
@@ -67,20 +67,4 @@ public class EventRepository {
             return null;
         }
     }
-
-//    private static class EventAsyncTask extends AsyncTask<List<Event>,Void,Void> {
-//        private final EventDao eventDao;
-//        String eventId = "";
-//
-//        public EventAsyncTask(EventDao eventDao) {
-//            this.eventDao = eventDao;
-//        }
-//
-//        @SafeVarargs
-//        @Override
-//        protected final Void doInBackground(List<Event>... lists) {
-//            eventDao.eventInCache(eventId);
-//            return null;
-//        }
-//    }
 }

--- a/app/src/main/java/com/capstone/event_finder/network/EventViewModel.java
+++ b/app/src/main/java/com/capstone/event_finder/network/EventViewModel.java
@@ -21,7 +21,7 @@ public class EventViewModel extends AndroidViewModel {
         super(application);
         eventRepository = new EventRepository(application);
         getEvents = eventRepository.getEvents();
-        eventInCache = eventRepository.eventInCache("boston-sincere-engineer-and-covey");
+        eventInCache = eventInCache("");
     }
 
     public void insert(List<Event> events) {
@@ -36,7 +36,7 @@ public class EventViewModel extends AndroidViewModel {
         return getEvents;
     }
 
-    public LiveData<List<Event>> eventInCache() {
-        return eventInCache;
+    public LiveData<List<Event>> eventInCache(String eventId) {
+        return eventRepository.eventInCache(eventId);
     }
 }

--- a/app/src/main/java/com/capstone/event_finder/network/EventViewModel.java
+++ b/app/src/main/java/com/capstone/event_finder/network/EventViewModel.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class EventViewModel extends AndroidViewModel {
 
     public LiveData<List<Event>> getEvents;
+    public LiveData<List<Event>> eventInCache;
 
     private final EventRepository eventRepository;
 
@@ -20,6 +21,7 @@ public class EventViewModel extends AndroidViewModel {
         super(application);
         eventRepository = new EventRepository(application);
         getEvents = eventRepository.getEvents();
+        eventInCache = eventRepository.eventInCache("boston-sincere-engineer-and-covey");
     }
 
     public void insert(List<Event> events) {
@@ -32,5 +34,9 @@ public class EventViewModel extends AndroidViewModel {
 
     public LiveData<List<Event>> getEvents() {
         return getEvents;
+    }
+
+    public LiveData<List<Event>> eventInCache() {
+        return eventInCache;
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,7 @@
         android:id="@+id/flContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@id/bottom_navigation"/>
+        android:layout_above="@id/bottom_navigation" />
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_navigation"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -20,6 +20,7 @@
         android:layout_height="wrap_content"
         android:layout_below="@+id/tvProfileUsername"
         android:layout_marginTop="136dp"
+        android:text="@string/bookmarks"
         android:textAppearance="@style/TextAppearance.AppCompat.Medium"
         tools:text="Bookmarks" />
 

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,14 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="16dp"
     tools:context="com.capstone.event_finder.fragments.ProfileFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Profile fragment with bookmarks here" />
+        android:id="@+id/tvProfileUsername"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+        tools:text="Orlando" />
 
-</FrameLayout>
+    <TextView
+        android:id="@+id/tvBookmarks"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvProfileUsername"
+        android:layout_marginTop="136dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        tools:text="Bookmarks" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvBookmarks"
+        android:layout_width="match_parent"
+        android:layout_height="486dp"
+        android:layout_below="@+id/tvBookmarks"
+        android:layout_marginTop="8dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,5 @@
     <string name="feed">Feed</string>
     <string name="profile">Profile</string>
     <string name="explore">Explore</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="bookmarks">Bookmarks</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="explore">Explore</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="bookmarks">Bookmarks</string>
 </resources>


### PR DESCRIPTION
New Stuff:
- User can view their profile with their username and bookmarked events
- User can see bookmarked feed and click on event to see details screen
- How it works:
    - Queried user bookmarks from Parse and retrieved event ids
    - If event id in local cache, retrieved event from local cache
    - If event id not in local cache, retrieved event from API


Notes:
- Would like to have a discussion about code organization for this particular commit since I needed to nest functions in order for bookmarkAdapter.notifyDataSetChanged() to not call something null - wondering if this has to do with async requests
- Planning to populate information below username with events user is interested in, user bio, user photo, and more as a stretch goal

Screenshot:
<img width="300" alt="Screen Shot 2022-07-11 at 2 08 03 PM" src="https://user-images.githubusercontent.com/59234861/178358614-bf39a35c-cba9-480e-b438-c14f8708ad66.png">