### PR TITLE
User can get recommended events based on their bookmarks and click on events to see details screen

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -17,7 +17,7 @@
         <entry key="app/src/main/res/layout/activity_photo_details.xml" value="0.26132246376811596" />
         <entry key="app/src/main/res/layout/activity_signup.xml" value="0.275433349609375" />
         <entry key="app/src/main/res/layout/activity_splash_screen.xml" value="0.25" />
-        <entry key="app/src/main/res/layout/fragment_explore.xml" value="0.29846014492753625" />
+        <entry key="app/src/main/res/layout/fragment_explore.xml" value="0.30745849609375003" />
         <entry key="app/src/main/res/layout/fragment_feed.xml" value="0.29846014492753625" />
         <entry key="app/src/main/res/layout/fragment_photo_details.xml" value="0.32997695165323027" />
         <entry key="app/src/main/res/layout/fragment_profile.xml" value="0.29846014492753625" />

--- a/app/src/main/java/com/capstone/event_finder/activities/SignUpActivity.java
+++ b/app/src/main/java/com/capstone/event_finder/activities/SignUpActivity.java
@@ -101,7 +101,7 @@ public class SignUpActivity extends AppCompatActivity {
         user.put("zip", etZip.getText().toString());
         user.put("bio", etBio.getText().toString());
         if (categoryListOfStrings == null) {
-            Toast.makeText(SignUpActivity.this, "Error: Sign up failed", Toast.LENGTH_LONG).show();
+            Toast.makeText(SignUpActivity.this, "Error: All fields are required", Toast.LENGTH_LONG).show();
             return;
         }
         user.put("event_categories", categoryListOfStrings);
@@ -109,7 +109,7 @@ public class SignUpActivity extends AppCompatActivity {
 
         user.signUpInBackground(e -> {
             if (e != null) {
-                Toast.makeText(SignUpActivity.this, "Error: Sign up failed", Toast.LENGTH_LONG).show();
+                Toast.makeText(SignUpActivity.this, "Error: All fields are required", Toast.LENGTH_LONG).show();
                 return;
             }
             Toast.makeText(SignUpActivity.this, "Sign up success!", Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
@@ -29,15 +29,20 @@ import org.json.JSONException;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ExploreFragment extends Fragment {
 
     private List<Event> recommendationList = new ArrayList<>();
     private JSONArray interestedCategories = new JSONArray();
-    private final List<Bookmark> bookmarksList = new ArrayList<>();
+    private List<Bookmark> bookmarksList = new ArrayList<>();
+    private Set<String> bookmarkCategories = new HashSet<String>();
 
     RecyclerView rvRecommendations;
     EventsAdapter recommendationAdapter;
@@ -55,8 +60,8 @@ public class ExploreFragment extends Fragment {
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         setUpRecyclerView(view);
-        JsonArray allBookmarks = new JsonArray();
-        queryUserBookmarksFromParse(allBookmarks);
+        ArrayList allBookmarkCategories = new ArrayList();
+        queryUserBookmarksFromParse(allBookmarkCategories);
 
         interestedCategories = ParseUser.getCurrentUser().getJSONArray("event_categories");
         for (int i =0; i < interestedCategories.length(); i++) {
@@ -76,7 +81,7 @@ public class ExploreFragment extends Fragment {
         rvRecommendations.setLayoutManager(linearLayoutManager);
     }
 
-    public void queryUserBookmarksFromParse(JsonArray allBookmarks) {
+    public void queryUserBookmarksFromParse(ArrayList allBookmarkCategories) {
         final int POST_LIMIT = 10;
         ParseQuery<Bookmark> query = ParseQuery.getQuery(Bookmark.class);
         query.whereEqualTo(Bookmark.KEY_USER, ParseUser.getCurrentUser());
@@ -89,17 +94,28 @@ public class ExploreFragment extends Fragment {
             }
             bookmarksList.clear();
             bookmarksList.addAll(bookmarks);
-            queryUserBookmarkCategories(allBookmarks);
+            queryUserBookmarkCategories(allBookmarkCategories);
         });
     }
 
-    private void queryUserBookmarkCategories(JsonArray allBookmarks) {
+    private void queryUserBookmarkCategories(ArrayList allBookmarkCategories) {
         for (int i = 0; i < bookmarksList.size(); i++) {
             Bookmark bookmark = bookmarksList.get(i);
             String bookmarkedEventCategory = bookmark.getEventCategory();
-            allBookmarks.add(bookmarkedEventCategory);
+            allBookmarkCategories.add(bookmarkedEventCategory);
+            bookmarkCategories.add(bookmarkedEventCategory);
         }
-        Log.d(TAG, allBookmarks.toString());
+        getCategoryOccurrence(allBookmarkCategories);
     }
+
+    private void getCategoryOccurrence(ArrayList allBookmarkCategories) {
+        Log.d(TAG, bookmarkCategories.toString());
+        Log.d(TAG, allBookmarkCategories.toString());
+        for (String category : bookmarkCategories) {
+            int occurrences = Collections.frequency(allBookmarkCategories, category);
+            Log.d(TAG, category + " : " + String.valueOf(occurrences));
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
@@ -1,16 +1,46 @@
 package com.capstone.event_finder.fragments;
 
+import static androidx.constraintlayout.helper.widget.MotionEffect.TAG;
+
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.capstone.event_finder.R;
+import com.capstone.event_finder.activities.MainActivity;
+import com.capstone.event_finder.adapters.EventsAdapter;
+import com.capstone.event_finder.models.Bookmark;
+import com.capstone.event_finder.models.Event;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.parse.ParseQuery;
+import com.parse.ParseUser;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class ExploreFragment extends Fragment {
+
+    private List<Event> recommendationList = new ArrayList<>();
+    private JSONArray interestedCategories = new JSONArray();
+    private final List<Bookmark> bookmarksList = new ArrayList<>();
+
+    RecyclerView rvRecommendations;
+    EventsAdapter recommendationAdapter;
 
     public ExploreFragment() {
     }
@@ -24,6 +54,52 @@ public class ExploreFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        setUpRecyclerView(view);
+        JsonArray allBookmarks = new JsonArray();
+        queryUserBookmarksFromParse(allBookmarks);
+
+        interestedCategories = ParseUser.getCurrentUser().getJSONArray("event_categories");
+        for (int i =0; i < interestedCategories.length(); i++) {
+            try {
+                Log.d(TAG, (String) interestedCategories.get(i));
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void setUpRecyclerView(@NonNull View view) {
+        rvRecommendations = view.findViewById(R.id.rvRecommendations);
+        recommendationAdapter = new EventsAdapter(getContext(), recommendationList);
+        rvRecommendations.setAdapter(recommendationAdapter);
+        LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getContext());
+        rvRecommendations.setLayoutManager(linearLayoutManager);
+    }
+
+    public void queryUserBookmarksFromParse(JsonArray allBookmarks) {
+        final int POST_LIMIT = 10;
+        ParseQuery<Bookmark> query = ParseQuery.getQuery(Bookmark.class);
+        query.whereEqualTo(Bookmark.KEY_USER, ParseUser.getCurrentUser());
+        query.setLimit(POST_LIMIT);
+        query.addDescendingOrder("createdAt");
+        query.findInBackground((bookmarks, e) -> {
+            if (e != null) {
+                Toast.makeText(getContext(), "Failed to find bookmarks", Toast.LENGTH_LONG).show();
+                return;
+            }
+            bookmarksList.clear();
+            bookmarksList.addAll(bookmarks);
+            queryUserBookmarkCategories(allBookmarks);
+        });
+    }
+
+    private void queryUserBookmarkCategories(JsonArray allBookmarks) {
+        for (int i = 0; i < bookmarksList.size(); i++) {
+            Bookmark bookmark = bookmarksList.get(i);
+            String bookmarkedEventCategory = bookmark.getEventCategory();
+            allBookmarks.add(bookmarkedEventCategory);
+        }
+        Log.d(TAG, allBookmarks.toString());
     }
 
 }

--- a/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/ExploreFragment.java
@@ -65,13 +65,13 @@ public class ExploreFragment extends Fragment {
         setUpRecyclerView(view);
         bookmarksList.clear();
         bookmarkCategories.clear();
-        getUserInterestedCategories();
-    }
-
-    private void getUserInterestedCategories() {
         ArrayList<String> allBookmarkCategories = new ArrayList<>();
         ArrayList<String> userInterestedCategories = new ArrayList<>();
+        includeUserInterestedCategories(userInterestedCategories);
         queryUserBookmarksFromParse(allBookmarkCategories, userInterestedCategories);
+    }
+
+    private void includeUserInterestedCategories(ArrayList<String> userInterestedCategories) {
         JSONArray interestedCategories = ParseUser.getCurrentUser().getJSONArray("event_categories");
         for (int i = 0; i < Objects.requireNonNull(interestedCategories).length(); i++) {
             try {
@@ -141,6 +141,7 @@ public class ExploreFragment extends Fragment {
         recommendationList.clear();
         for (String category : bookmarkCategories) {
             int count = (int) (Math.ceil(10 * (categoryCount.get(category) / totalPoints)));
+            categoryCount.put(category, (double) count);
             getAPIEvents(category, Integer.toString(count));
         }
     }

--- a/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
+++ b/app/src/main/java/com/capstone/event_finder/fragments/FeedFragment.java
@@ -1,5 +1,6 @@
 package com.capstone.event_finder.fragments;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -84,11 +85,13 @@ public class FeedFragment extends Fragment implements EventFetcherInterface {
         String eventSearchRegion = "en_US";
         Long eventSearchRadiusFromUserInMeters = 40000L;
         String numberOfEventsToRetrieve = "10";
+        String categories = "music, visual-arts, performing-arts, film, lectures-books, fashion, food-and-drink, festivals-fairs, charities, sports-active-life, nightlife, kids-family, other";
         Long upcomingEventsOnly = (System.currentTimeMillis() / 1000L);
         RetrofitClient.getInstance().getYelpAPI().getEvents(eventSearchRegion,
                 numberOfEventsToRetrieve,
                 upcomingEventsOnly,
                 eventSearchRadiusFromUserInMeters,
+                categories,
                 ParseUser.getCurrentUser().getString("zip")).enqueue(new Callback<JsonObject>() {
             @Override
             public void onResponse(@NonNull Call<JsonObject> call, @NonNull Response<JsonObject> response) {
@@ -107,17 +110,20 @@ public class FeedFragment extends Fragment implements EventFetcherInterface {
     }
 
     private void addEventsToDatabase(@NonNull Response<JsonObject> response) {
-        requireActivity().runOnUiThread(() -> {
-            try {
-                JsonObject result = response.body();
-                eventsList.clear();
-                assert result != null;
-                clearAndAddEventsToDatabase(result);
-                eventsAdapter.notifyDataSetChanged();
-            } catch (Exception e) {
-                Toast.makeText(getContext(), "JSON exception error", Toast.LENGTH_SHORT).show();
-            }
-        });
+        Activity activity = getActivity();
+        if (activity != null) {
+            requireActivity().runOnUiThread(() -> {
+                try {
+                    JsonObject result = response.body();
+                    eventsList.clear();
+                    assert result != null;
+                    clearAndAddEventsToDatabase(result);
+                    eventsAdapter.notifyDataSetChanged();
+                } catch (Exception e) {
+                    Toast.makeText(getContext(), "JSON exception error", Toast.LENGTH_SHORT).show();
+                }
+            });
+        }
     }
 
     private void tryLocallyCaching() {

--- a/app/src/main/java/com/capstone/event_finder/interfaces/EventEndpointsInterface.java
+++ b/app/src/main/java/com/capstone/event_finder/interfaces/EventEndpointsInterface.java
@@ -13,6 +13,7 @@ public interface EventEndpointsInterface {
                                @Query("limit") String limit,
                                @Query("start_date") Long start_date,
                                @Query("radius") Long radius,
+                               @Query("categories") String category,
                                @Query("location") String location);
 
     @GET("events/{id}")

--- a/app/src/main/res/layout/fragment_explore.xml
+++ b/app/src/main/res/layout/fragment_explore.xml
@@ -1,13 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_margin="16dp"
     tools:context="com.capstone.event_finder.fragments.ExploreFragment">
 
     <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Explore events (recommendations) fragment" />
+        android:id="@+id/tvExplore"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/events_for_you"
+        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+        tools:text="Events for you" />
 
-</FrameLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvRecommendations"
+        android:layout_width="match_parent"
+        android:layout_height="631dp"
+        android:layout_below="@+id/tvExploreDescription"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/tvExploreDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/tvExplore"
+        android:layout_marginTop="6dp"
+        android:text="@string/recommendations_curated_just_for_you"
+        android:textStyle="italic"
+        tools:text="Recommendations curated just for you!" />
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,6 @@
     <string name="bio_here">Bio here</string>
     <string name="interest_categories">Interests:</string>
     <string name="example_categories">lectures-books, fashion</string>
+    <string name="events_for_you">Events for you</string>
+    <string name="recommendations_curated_just_for_you">Recommendations curated just for you!</string>
 </resources>


### PR DESCRIPTION
New stuff:
- User can get recommended events based on their bookmarks and click on events to see details screen

How the number of recommended events to query are calculated:
> Point system:
> - For each category of interest: +1 pts
> - For each bookmark in event category of interest: +3 pts
> - For each bookmark not in event category of interest: + 2 pts
> 
> Steps:
> - Calculate points for each category based on point system
> - Get percentage of each event by dividing points in each category by total points 
> - Get the whole numbers of each percentage from 10, which will be the number of events of each category to query
> - Query number of events of each category and populate the recommendation feed (note that if event within range not available, will not query anything of that category)

Screenshot:

<img width="300" alt="Screen Shot 2022-07-14 at 3 20 56 PM" src="https://user-images.githubusercontent.com/59234861/179098222-ba6b2502-f7a2-4b75-ab21-d22c8c948f2b.png">
